### PR TITLE
feat: add configurable max_num_seqs parameter to AsyncvLLMServer

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -217,6 +217,7 @@ class AsyncvLLMServer(AsyncServerBase):
 
         tensor_parallel_size = config.get("tensor_model_parallel_size", 1)
         max_num_batched_tokens = config.get("max_num_batched_tokens", 8192)
+        max_num_seqs = config.get("max_num_seqs", 1024)
         max_model_len = config.max_model_len if config.max_model_len else config.prompt_length + config.response_length
         self.max_model_len = int(max_model_len)
 
@@ -256,6 +257,7 @@ class AsyncvLLMServer(AsyncServerBase):
             load_format="auto",
             disable_log_stats=config.disable_log_stats,
             max_num_batched_tokens=max_num_batched_tokens,
+            max_num_seqs=max_num_seqs,
             enable_chunked_prefill=config.enable_chunked_prefill,
             enable_prefix_caching=True,
             trust_remote_code=trust_remote_code,


### PR DESCRIPTION
- Add max_num_seqs parameter support in AsyncvLLMServer class
- Allow max_num_seqs to be configured via config files instead of hardcoding
- Pass max_num_seqs to AsyncEngineArgs for vLLM engine initialization
- Default value set to 1024 to maintain backward compatibility